### PR TITLE
feat: Move inline scripts to external

### DIFF
--- a/root/index.css
+++ b/root/index.css
@@ -1,0 +1,9 @@
+body {
+  font-family: 'Open Sans', Helvetica, Arial, sans-serif;
+}
+.message {
+  padding-top: 100px;
+  color: #555;
+  text-align: center;
+  font-size: 1.5em;
+}

--- a/root/index.html
+++ b/root/index.html
@@ -4,28 +4,8 @@
         <meta charset="UTF-8" />
         <meta name="viewport" content="width=device-width, initial-scale=1.0" />
         <title>Nijmegen component library</title>
-        <script>
-            var httpRequest = new XMLHttpRequest();
-            httpRequest.onreadystatechange = function() {
-                if (httpRequest.readyState === XMLHttpRequest.DONE && httpRequest.status === 200) {
-                    var version = JSON.parse(httpRequest.responseText);
-                    location.href = '/v' + version.latest + '/';
-                }
-            };
-            httpRequest.open('GET', '/version.json', true);
-            httpRequest.send();
-        </script>
-        <style>
-            body {
-                font-family: 'Open Sans', Helvetica, Arial, sans-serif;
-            }
-            .message {
-                padding-top: 100px;
-                color: #555;
-                text-align: center;
-                font-size: 1.5em;
-            }
-        </style>
+        <script src="/index.js"></script>
+        <script src="/index.css"></script>
     </head>
     <body>
         <div class="message">Redirecting to the latest version ...</div>

--- a/root/index.js
+++ b/root/index.js
@@ -1,0 +1,9 @@
+var httpRequest = new XMLHttpRequest();
+httpRequest.onreadystatechange = function() {
+    if (httpRequest.readyState === XMLHttpRequest.DONE && httpRequest.status === 200) {
+        var version = JSON.parse(httpRequest.responseText);
+        location.href = '/v' + version.latest + '/';
+    }
+};
+httpRequest.open('GET', '/version.json', true);
+httpRequest.send();


### PR DESCRIPTION
CSP-headers prevent inline scripts and styling from being executed. This moves the redirect-index-script (and styling) to separate files.