### PR TITLE
Fix/use nlds next to mdbs

### DIFF
--- a/changelogs/unreleased/use-nlds-besides-mdbs.yml
+++ b/changelogs/unreleased/use-nlds-besides-mdbs.yml
@@ -1,0 +1,6 @@
+versionBump: patch 
+changes:
+  - type: changed 
+    component: nijmegen-button
+    description: wrapped rendered component css inside nijmegen-theme class
+    what: [CSS] 

--- a/docs/02-NL Design System.md
+++ b/docs/02-NL Design System.md
@@ -23,6 +23,8 @@ The Nijmegen NLDS components styles will only be applied inside the `nijmegen-th
 </div>
 ```
 
+Best practice to use the NLDS Nijmegen theme is to apply the `nijmegen-theme` class on the body element as stated in the example below.
+
 ### Example use NLDS and MD Bootstrap components
 ```html
 <!doctype html>
@@ -69,7 +71,7 @@ The Nijmegen NLDS components styles will only be applied inside the `nijmegen-th
 
     <title>Titel van de pagina</title>
 </head>
-<body>
+<body class="nijmegen-theme">
 
 <main>
     <!-- START: MD Bootstrap component(s) -->
@@ -77,11 +79,7 @@ The Nijmegen NLDS components styles will only be applied inside the `nijmegen-th
     <!-- END: MD Bootstrap component(s) -->
     
     <!-- START: NLDS Nijmegen theme -->
-    <div class="nijmegen-theme">
-        <!-- START: NLDS Nijmegen component(s) -->
-            <!-- ... -->
-        <!-- END: NLDS Nijmegen component(s) -->
-    </div>
+    <!-- ... -->
     <!-- END: NLDS Nijmegen theme -->
 </main>
 

--- a/src/nlds/scss/main.scss
+++ b/src/nlds/scss/main.scss
@@ -1,2 +1,4 @@
 @use '@gemeentenijmegen/design-tokens/dist/index.css';
-@import '@utrecht/components/button/css/index';
+.nijmegen-theme {
+    @import '@utrecht/components/button/css/index';
+}


### PR DESCRIPTION
nijmegen.nl blijft bij de implementatie MDBS classed en NLDS classes toepassen op elementen. Om ervoor te zorgen dat de NLDS styles "winnen" wrappen we de componenten css binnen het `nijmegen-theme` class. Op Design System niveau gaan we dit niet doen omdat dit strookt met het handboek maar voor de component library is dit een prima oplossing omdat we hier alle componenten vanuit 1 rendered css aanbieden.

Voor deze pr:
![Scherm­afbeelding 2025-01-13 om 12 54 19](https://github.com/user-attachments/assets/f8eb4b7d-dae8-40f9-847b-bbdd29f39472)

Na deze pr:
![Scherm­afbeelding 2025-01-13 om 12 59 57](https://github.com/user-attachments/assets/3a055b8b-f204-4997-93ea-8d1cde69fe1f)

Blijft wel een punt dat we ieder component even moeten testen op conflicten omdat MDBS classes ook applied blijven op de elementen, dit is niet ideaal.
